### PR TITLE
Reworking auto-yasnippet examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,90 +71,67 @@ I also like to bind this, instead of using <kbd>TAB</kbd> to expand yasnippets:
 (global-set-key (kbd "C-o") #'aya-open-line)
 ```
 
-# Usage examples
+# Usage
 
-## JavaScript
+## A basic example
 
-```js
-field~1 = document.getElementById("field~1");
-```
-
-Since this just one line,
-just call `aya-create` (from anywhere on this line).
-The `~` chars disappear, yielding valid code.
-
-`aya-current` becomes:
-
-```cl
-"field$1 = document.getElementById(\"field$1\");"
-```
-
-Now by calling `aya-expand` multiple times, you get:
+Suppose we want to write:
 
 ```js
-field1 = document.getElementById("field1");
-field2 = document.getElementById("field2");
-field3 = document.getElementById("field3");
-fieldFinal = document.getElementById("fieldFinal");
+count_of_red = get_total("red");
+count_of_blue = get_total("blue");
+count_of_green = get_total("green");
 ```
 
-## Java
+We write a template, using ~ to represent variables that we want to
+replace:
 
-```java
-class Light~On implements Runnable {
-  public Light~On() {}
-  public void run() {
-    System.out.println("Turning ~on lights");
-    light = ~true;
-  }
+```
+count_of_~red = get_total("~red");
+```
+
+Call `aya-create` with point on this line, and the template is
+converted to a value we want:
+
+```
+count_of_red = get_total("red");
+```
+
+Then call `aya-expand` and you can 'paste' additional instances of
+the template. Yasnippet is active, so you can tab between
+placeholders as usual.
+
+```
+count_of_red = get_total("red");
+count_of_ = get_total("");
+```
+
+## Inline text
+
+`~` replaces the symbol after it. If you want to replace arbitrary
+text, use Emacs-style backticks:
+
+```
+`red'_total = get_total("`red'_values");
+```
+
+## Multiple placeholders
+
+You can replace multiple values in a template, just like normal
+yasnippet.
+
+In this example, our template has multiple lines, so we need to
+select the relevant lines before calling `aya-create`.
+
+```
+~FooType get~Foo() {
+    // Get the ~foo attribute on this.
+    return this.~foo;
 }
 ```
 
-This differs from the code that you wanted to write only by 4 `~` chars.
-Since it's more than one line, select the region and call `aya-create`.
-Again, the `~` chars disappear, yielding valid code.
-
-`aya-current` becomes:
-
-```cl
-"class Light$1 implements Runnable {
-  public Light$1() {}
-  public void run() {
-    System.out.println(\"Turning $2 lights\");
-    light = $3;
-  }
-}"
-```
-
-Now by calling `aya-expand`, you can quickly fill in:
-
-```java
-class LightOff implements Runnable {
-  public LightOff() {}
-  public void run() {
-    System.out.println("Turning off lights");
-    light = false;
-  }
-}
-```
-
-## C++
-
-```c++
-const Point<3> curl(grad[~2][~1] - grad[~1][~2],
-```
-
-Select the region between the paren and the comma and call `aya-create`.
-You can easily obtain the final code:
-
-```c++
-const Point<3> curl(grad[2][1] - grad[1][2],
-                    grad[0][2] - grad[2][0],
-                    grad[1][0] - grad[0][1]);
-```
-
-Note how annoying it would be to triple check that the indices match.
-Now you just have to check for one line.
+We only fill in three placeholders in this example (the fourth is
+the same as the third).
 
 ## JavaScript - `aya-one-line`:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Auto-YASnippet
 
 This is a hybrid of
-[keyboard macro](http://www.gnu.org/software/emacs/manual/html_node/emacs/Basic-Keyboard-Macro.html)
+[keyboard macros](http://www.gnu.org/software/emacs/manual/html_node/emacs/Basic-Keyboard-Macro.html)
 and [yasnippet](http://code.google.com/p/yasnippet/).  You create the
 snippet on the go, usually to be used just in the one place.  It's
 fast, because you're not leaving the current buffer, and all you do is

--- a/README.md
+++ b/README.md
@@ -8,41 +8,24 @@ fast, because you're not leaving the current buffer, and all you do is
 enter the code you'd enter anyway, just placing `~` where you'd like
 yasnippet fields and mirrors to be.
 
-## Functions
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
+**Table of Contents**
 
-### aya-create
+- [Auto-YASnippet](#auto-yasnippet)
+- [Installation instructions](#installation-instructions)
+- [Usage](#usage)
+    - [A basic example](#a-basic-example)
+    - [Inline text](#inline-text)
+    - [Multiple placeholders](#multiple-placeholders)
+    - [JavaScript - `aya-one-line`:](#javascript---aya-one-line)
+    - [Generating comments](#generating-comments)
+- [Functions](#functions)
+    - [aya-create](#aya-create)
+    - [aya-expand](#aya-expand)
+    - [aya-open-line](#aya-open-line)
+    - [aya-persist-snippet](#aya-persist-snippet)
 
-Removes "~" from current line or region (if mark is active)
-yielding valid code.
-The created snippet is recorded into `aya-current`.
-
-### aya-expand
-
-Expands whatever is currently in `aya-current`
-
-### aya-open-line
-
-Generic expansion function. It will either expand or move
-to the next field depending on the context.
-
-### aya-persist-snippet
-
-Save the current auto-snippet to a user snippets folder (this defaults to
-`~/.emacs.d/snippets/`.)  The current `major-mode` name will be used
-to determine the snippets sub-directory to store the snippet.  For
-example when working in `js2-mode` the snippet will be saved to (by
-default) `~/.emacs.d/snippets/js2-mode/`.
-
-You will be prompted for the snippet **name**. The appropriate file will be opened but not saved,
-with the point on the `key: ` parameter of the snippet. If you wish to proceed, fill in the key,
-save the buffer and call <kbd>C-c C-l</kbd> (`yas-load-snippet-buffer`). Otherwise, simply kill the
-buffer - there will be no side effects.
-
-You can customize `aya-persist-snippets-dir` to use a different folder
-for storing auto-snippets.
-
-You will need to run `yas/reload-all` before using the new snippet
-with it's **key** trigger.
+<!-- markdown-toc end -->
 
 # Installation instructions
 
@@ -167,3 +150,39 @@ Here's a yasnippet that makes use of `aya-tab-position`. You need to call
 
 Comments generated with this will always end in same column position,
 no matter from which indentation level they were invoked from.
+
+# Functions
+
+## aya-create
+
+Removes "~" from current line or region (if mark is active)
+yielding valid code.
+The created snippet is recorded into `aya-current`.
+
+## aya-expand
+
+Expands whatever is currently in `aya-current`
+
+## aya-open-line
+
+Generic expansion function. It will either expand or move
+to the next field depending on the context.
+
+## aya-persist-snippet
+
+Save the current auto-snippet to a user snippets folder (this defaults to
+`~/.emacs.d/snippets/`.)  The current `major-mode` name will be used
+to determine the snippets sub-directory to store the snippet.  For
+example when working in `js2-mode` the snippet will be saved to (by
+default) `~/.emacs.d/snippets/js2-mode/`.
+
+You will be prompted for the snippet **name**. The appropriate file will be opened but not saved,
+with the point on the `key: ` parameter of the snippet. If you wish to proceed, fill in the key,
+save the buffer and call <kbd>C-c C-l</kbd> (`yas-load-snippet-buffer`). Otherwise, simply kill the
+buffer - there will be no side effects.
+
+You can customize `aya-persist-snippets-dir` to use a different folder
+for storing auto-snippets.
+
+You will need to run `yas/reload-all` before using the new snippet
+with its **key** trigger.

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ you haven't done so recently).
 You will also want to setup the key bindings. Here's what I recommend:
 
 ```cl
-(global-set-key (kbd "H-w") 'aya-create)
-(global-set-key (kbd "H-y") 'aya-expand)
+(global-set-key (kbd "H-w") #'aya-create)
+(global-set-key (kbd "H-y") #'aya-expand)
 ```
 
 I also like to bind this, instead of using <kbd>TAB</kbd> to expand yasnippets:
 
 ```cl
-(global-set-key (kbd "C-o") 'aya-open-line)
+(global-set-key (kbd "C-o") #'aya-open-line)
 ```
 
 # Usage examples

--- a/auto-yasnippet.el
+++ b/auto-yasnippet.el
@@ -36,67 +36,57 @@
 ;;     (global-set-key (kbd "H-w") #'aya-create)
 ;;     (global-set-key (kbd "H-y") #'aya-expand)
 
-;; Usage:
-;; e.g. in JavaScript write:
+;;; Usage:
+;; auto-yasnippet allows you to quickly write verbose code using an
+;; example as a template.
 ;;
-;; field~1 = document.getElementById("field~1");
+;; (1) A basic example
 ;;
-;; Since this just one line,
-;; just call `aya-create' (from anywhere on this line).
-;; The ~ chars disappear, yielding valid code.
-;; `aya-current' becomes:
-;; "field$1 = document.getElementById(\"field$1\");"
-;; Now by calling `aya-expand' multiple times, you get:
+;; Suppose we want to write:
 ;;
-;; field1 = document.getElementById("field1");
-;; field2 = document.getElementById("field2");
-;; field3 = document.getElementById("field3");
-;; fieldFinal = document.getElementById("fieldFinal");
+;; count_of_red = get_total("red");
+;; count_of_blue = get_total("blue");
+;; count_of_green = get_total("green");
 ;;
-;; e.g. in Java write:
+;; We write a template, using ~ to represent variables that we want to
+;; replace:
 ;;
-;; class Light~On implements Runnable {
-;;   public Light~On() {}
-;;   public void run() {
-;;     System.out.println("Turning ~on lights");
-;;     light = ~true;
-;;   }
+;; count_of_~red = get_total("~red");
+;;
+;; Call `aya-create' with point on this line, and the template is
+;; converted to a value we want:
+;;
+;; count_of_red = get_total("red");
+;;
+;; Then call `aya-expand' and you can 'paste' additional instances of
+;; the template. Yasnippet is active, so you can tab between
+;; placeholders as usual.
+;;
+;; count_of_red = get_total("red");
+;; count_of_ = get_total("");
+;;
+;; (2) Inline text
+;;
+;; ~ replaces the symbol after it. If you want to replace arbitrary
+;; text, use Emacs-style backticks:
+;;
+;; `red'_total = get_total("`red'_values");
+;;
+;; (3) Multiple placeholders
+;;
+;; You can replace multiple values in a template, just like normal
+;; yasnippet.
+;;
+;; In this example, our template has multiple lines, so we need to
+;; select the relevant lines before calling `aya-create'.
+;;
+;; ~FooType get~Foo() {
+;;     // Get the ~foo attribute on this.
+;;     return this.~foo;
 ;; }
 ;;
-;; This differs from the code that you wanted to write only by 4 ~ chars.
-;; Since it's more than one line, select the region and call `aya-create'.
-;; Again, the ~ chars disappear, yielding valid code.
-;; `aya-current' becomes:
-;; "class Light$1 implements Runnable {
-;;   public Light$1() {}
-;;   public void run() {
-;;     System.out.println(\"Turning $2 lights\");
-;;     light = $3;
-;;   }
-;; }"
-;;
-;; Now by calling `aya-expand', you can quickly fill in:
-;; class LightOff implements Runnable {
-;;   public LightOff() {}
-;;   public void run() {
-;;     System.out.println("Turning off lights");
-;;     light = false;
-;;   }
-;; }
-;;
-;; e.g. in C++ write:
-;; const Point<3> curl(grad[~2][~1] - grad[~1][~2],
-;;
-;; select the region between the paren and the comma and call `aya-create'.
-;;
-;; You can easily obtain the final code:
-
-;; const Point<3> curl(grad[2][1] - grad[1][2],
-;;                     grad[0][2] - grad[2][0],
-;;                     grad[1][0] - grad[0][1]);
-;;
-;; Note how annoying it would be to triple check that the indices match.
-;; Now you just have to check for one line.
+;; We only fill in three placeholders in this example (the fourth is
+;; the same as the third).
 
 ;;; Code:
 (require 'yasnippet nil t)

--- a/auto-yasnippet.el
+++ b/auto-yasnippet.el
@@ -33,8 +33,8 @@
 ;;
 ;; 3. In your .emacs file:
 ;;     (require 'auto-yasnippet)
-;;     (global-set-key (kbd "H-w") 'aya-create)
-;;     (global-set-key (kbd "H-y") 'aya-expand)
+;;     (global-set-key (kbd "H-w") #'aya-create)
+;;     (global-set-key (kbd "H-y") #'aya-expand)
 
 ;; Usage:
 ;; e.g. in JavaScript write:


### PR DESCRIPTION
I think this is clearer. I've avoided using numbers after `~`, added more examples, and documented inline substitutions.

Do let me know what you think :)