### PR TITLE
add new option: aya-case-fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ yasnippet fields and mirrors to be.
     - [Multiple placeholders](#multiple-placeholders)
     - [JavaScript - `aya-one-line`:](#javascript---aya-one-line)
     - [Generating comments](#generating-comments)
+    - [Mixed case templates](#mixed-case-templates)
 - [Functions](#functions)
     - [aya-create](#aya-create)
     - [aya-expand](#aya-expand)
@@ -150,6 +151,28 @@ Here's a yasnippet that makes use of `aya-tab-position`. You need to call
 
 Comments generated with this will always end in same column position,
 no matter from which indentation level they were invoked from.
+
+## Mixed case templates
+
+You can create mixed case templates setting `aya-case-fold` to `t`. This will result
+in templates where variables that start with a character of a different case will be
+treated as the same variable. The case of the first character will be preserved in the
+resulting snippet.
+
+Using the earlier example with a slight twist:
+
+```
+count_of_~red = get_total("~Red");
+```
+
+Then calling `aya-create`, then `aya-expand`, and finally typing `blue`, the result
+would be:
+
+```
+count_of_blue = get_total("Blue");
+```
+
+Notice that `blue` was placed in both locations with proper casing.
 
 # Functions
 


### PR DESCRIPTION
This pull request adds support for the option `aya-case-fold`. This option essentially allows auto-yasnippet to create templates where variables that are identical apart from the case of the first character are linked together to a single variable with case in the resulting snippet is preserved. 

I know that sounds like a mouthful, but the easiest way to see the behavior is in this screencast (first with this setting disabled, then again with it enabled):

![screencast](http://drop.bryan.sh/GLVxyzsBkQ.gif)

I modeled this feature after the ability to find and replace text while preserving the case of the initial character: https://www.emacswiki.org/emacs/CaseFoldSearch.

The code is fairly straightforward. I'm now returning an alist from `aya--parse` that contains the `id` of the match, it's `value`, and `ucase` (whether or not the value was uppercase or not). That alist is used to both recreate the current line with proper casing and create a yas template that conditionally uppercases the value to match the original casing.