### PR TITLE
Add optional args BEG, END to `aya-create`

### DIFF
--- a/auto-yasnippet.el
+++ b/auto-yasnippet.el
@@ -233,19 +233,21 @@ menu.add_item(spamspamspam, \"spamspamspam\")"
     (nreverse res)))
 
 ;;;###autoload
-(defun aya-create ()
-  "Works on either the current line, or, if `mark-active', the current region.
+(defun aya-create (&optional beg end)
+  "If no options are given, works on either the current line, or, if `mark-active', the current region. Else, works on the region given by BEG and END.
 Removes `aya-marker' prefixes,
 writes the corresponding snippet to `aya-current',
 with words prefixed by `aya-marker' as fields, and mirrors properly set up."
   (interactive)
   (unless (aya-create-one-line)
-    (let* ((beg (if (region-active-p)
-                    (region-beginning)
-                  (line-beginning-position)))
-           (end (if (region-active-p)
-                    (region-end)
-                  (line-end-position)))
+    (let* ((beg (if beg beg
+                  (if (region-active-p)
+                      (region-beginning)
+                    (line-beginning-position))))
+           (end (if end end
+                  (if (region-active-p)
+                      (region-end)
+                    (line-end-position))))
            (str (buffer-substring-no-properties beg end))
            (case-fold-search nil)
            (res (aya--parse str)))


### PR DESCRIPTION
This commit adds optional arguments BEG and END to `aya-create`. These arguments allow the to explicitly set the region for `aya-create` to work on.

Since the arguments are optional, and the function took no arguments previously, this change is fully backwards-compatible.

The new arguments give more flexibility to customize auto-yasnippet. Personally, I am using them to integrate with evil-mode by advising evil-yank and evil-paste to create/expand snippets when needed.

I'll note that my experience with elisp is somewhat limited, so if there are better ways of doing this then I'll be happy to change the approach here.