### PR TITLE
Change cl-some #'listp to listp in aya-create

### DIFF
--- a/auto-yasnippet.el
+++ b/auto-yasnippet.el
@@ -271,7 +271,7 @@ mirrors properly set up."
            (str (buffer-substring-no-properties beg end))
            (case-fold-search nil)
            (res (aya--parse str)))
-      (when (cl-some #'listp res)
+      (when (listp res)
         (delete-region beg end)
         (insert (mapconcat
                  (lambda (x) (if (listp x) (aya--alist-get-proper-case-value x) x))


### PR DESCRIPTION
`res` seems to be a list of strings, not a list of lists. `aya-create` was not working for me before this change, it didn't register the region, and now it does.